### PR TITLE
chore: cleaned up error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,50 +3,54 @@
 <p align="right"><strong>English</strong> | <a href="https://github.com/aptend/typing-transformer-obsidian/blob/main/README-CN.md">中文</a></p>
 
 ---
+# Obsidian Typing Transformer
 
 Typing Transformer is inspired by [Easy Typing](https://github.com/Yaozhuwa/easy-typing-obsidian), thanks to Easy Typing!
 
-Typing Transofrmer has clean internal rules, flexible configuration and allows users to have a customized auto-formatting experience as typing
+Typing Transofrmer has clean internal rules, flexible configuration and provides users a customized auto-formatting experience as typing
 
 **Note: The implementation depends on CodeMirror6 and only works in non-legacy mode in Obsidian 0.14.15 or later**
 
-## Configurable input conversion
+## Input Conversion
 
-
-Typing Trasnformer supports automatic expansion of predefined snippets on input.
+Typing Transformer supports automatic expansion of predefined snippets on input.
 
 ![conversion](https://user-images.githubusercontent.com/49832303/175769416-c0fce828-cf72-4d2d-b74d-8bf35f78ce27.gif)
 
-For example, a rule is now configured as follows
+## Examples
+`'dpx|' -> 'don\'t panic|'` 
 
-```
-'dpx|' -> 'don\'t panic|'
-```
+When `dp` is followed by `x`, the conversion is triggered. `dpx` turns into `don't panic`
 
-where `|` indicates the cursor position. `dpx|` is the trigger rule, when `dp` is entered and then `x` follows, the conversion is triggered and the entered `dp` will be replaced by `don't panic` and the cursor will be placed at the end of `panic`.
+`dpx|` is the trigger rule and `don\'t panic|` is the conversion result. `|` indicates the cursor position (you can place the cursor anywhere in the trigger rule or conversion result).
 
+*Note: Some special characters such as `|`, `'`, `"` have to be escaped with a backslash.*
 
-In addition to helping us expand abbreviated phrases, this feature can also handle symbol conversions, such as auto-pairing symbols, or turning fullwidth symbols into halfwidth ones, examples:
-- `'《|' -> '《|》'` rule describes the automatic matching of Chinese book marks and placing the cursor in the middle
-- `'。。|' -> '.|'` rule describes the transformation of two Chinese periods into one English period
+In addition to helping us expand abbreviated phrases, this plugin can also handle symbol conversions.
+
+You can auto-pairing symbols:
+- `'《|' -> '《|》'` auto-pairs Chinese bookmarks and places the cursor in the middle (as indicated by `|`)
+
+or turn fullwidth characters into halfwidth ones.
+
+- `'。。|' -> '.|'` transforms of two Chinese periods `。` into one English period `.`
 
 **Refer to more rules in the setting page of Typing Transfomer and have fun converting!**
 
-## Configiurable paired symbols insertion to selection
+## Auto-pairing selection rule
 
-When an area is selected and some symbols are entered, corresponding paired symbols are automatically added to both sides of the selected area.
+When an area is selected and a trigger character are entered, corresponding paired symbols are automatically added to both sides of the selected area.
 
-The following symbols are currently supported by default.
+The following symbols are currently supported by default:
 
-- `selected` + `·` -> `` `selected` ``
-- `selected` + `￥` -> `$selected$`
-- `selected` + `<`  -> `<selected>`
-- `selected` + `《`  -> `《selected》`
+- `sel` + `·` -> `` `sel` ``
+- `sel` + `￥` -> `$sel$`
+- `sel` + `<`  -> `<sel>`
+- `sel` + `《`  -> `《sel》`
 
 As with the conversion rules, **selection rules can also be created in the Typing Transformer's settings page**. The basic format is:
 
-`'trigger char' -> 'left-insert-char' + 'right-insert-char'`
-
+`'<trigger char>' -> '<left-insert-char>' + '<right-insert-char>'`
 
 ## Format line with spaces
 
@@ -55,5 +59,3 @@ When typing in multiple languages, inserting spaces between different language b
 ![add spaces](https://user-images.githubusercontent.com/49832303/175770015-6dba97d6-5eb2-4d30-a28d-e7ae061c2e7a.gif)
 
 In most cases, the range of auto-formatting is a short sentence, and the actual processing part will have "⭐️" to indicate the starting point and have the current cursor position to be the end point. The timing of the formatting is usually when you enter a sentence punctuation, such as a comma, a period, a space can also do.
-
-

--- a/README.md
+++ b/README.md
@@ -15,25 +15,29 @@ Typing Transofrmer has clean internal rules, flexible configuration and provides
 
 Typing Transformer supports automatic expansion of predefined snippets on input.
 
-![conversion](https://user-images.githubusercontent.com/49832303/175769416-c0fce828-cf72-4d2d-b74d-8bf35f78ce27.gif)
+![dpx](https://user-images.githubusercontent.com/103465188/183317743-3ee2a6b2-2b08-427b-886d-d212d4c94fb8.gif)
 
-![dpx](https://user-images.githubusercontent.com/103465188/183317350-af1c321b-e2c8-46db-b73a-58cc517c0de1.gif)
-
-When `dp` is followed by `x`, the conversion is triggered. `dpx` turns into `don't panic`
+When `dp` is followed by `x`, the conversion is triggered and `dpx` turns into `don't panic`.
 
 `dpx|` is the trigger rule and `don\'t panic|` is the conversion result. `|` indicates the cursor position (you can place the cursor anywhere in the trigger rule or conversion result).
 
-*Note: Some special characters such as `|`, `'`, `"` have to be escaped with a backslash.*
+*Note: Some special characters such as `'`, `"`, or the literal `|` character have to be escaped with a backslash.*
 
+---
 In addition to helping us expand abbreviated phrases, this plugin can also handle symbol conversions.
 
 You can auto-pair bracekts:
-- `'<' -> '<|>'` auto-pairs angled brackets and places the cursor in the middle (as indicated by `|`)
+
+![autopair](https://user-images.githubusercontent.com/103465188/183318512-d5c5d65b-5b4e-464e-a453-b39c5775fdc1.gif)
+- `'<|' -> '<|>'` auto-pairs angled brackets and places the cursor in the middle (as indicated by `|`)
 - `'《|' -> '《|》'` auto-pairs Chinese bookmarks and places the cursor in the middle (as indicated by `|`)
 
-or turn fullwidth characters into halfwidth ones.
+or turn full width characters into half width ones:
 
+![width conversion](https://user-images.githubusercontent.com/103465188/183317990-66464aec-9a87-46fe-9809-04d13e77e9b4.gif)
 - `'。。|' -> '.|'` transforms of two Chinese periods `。` into one English period `.`
+
+
 
 **Refer to more rules in the setting page of Typing Transfomer and have fun converting!**
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Typing Transformer supports automatic expansion of predefined snippets on input.
 
 ![conversion](https://user-images.githubusercontent.com/49832303/175769416-c0fce828-cf72-4d2d-b74d-8bf35f78ce27.gif)
 
-## Examples
-`'dpx|' -> 'don\'t panic|'` 
+![dpx](https://user-images.githubusercontent.com/103465188/183317350-af1c321b-e2c8-46db-b73a-58cc517c0de1.gif)
 
 When `dp` is followed by `x`, the conversion is triggered. `dpx` turns into `don't panic`
 
@@ -28,7 +27,8 @@ When `dp` is followed by `x`, the conversion is triggered. `dpx` turns into `don
 
 In addition to helping us expand abbreviated phrases, this plugin can also handle symbol conversions.
 
-You can auto-pairing symbols:
+You can auto-pair bracekts:
+- `'<' -> '<|>'` auto-pairs angled brackets and places the cursor in the middle (as indicated by `|`)
 - `'《|' -> '《|》'` auto-pairs Chinese bookmarks and places the cursor in the middle (as indicated by `|`)
 
 or turn fullwidth characters into halfwidth ones.

--- a/src/ext_convert.ts
+++ b/src/ext_convert.ts
@@ -245,7 +245,7 @@ class RuleParser {
             }
         }
         if (ch != '\n' && ch != EOF) {
-            return Err("Expected only one rule in each line, but found " + ch);
+            return Err("Expected only one rule on each line, but found " + ch);
         }
         return Ok("#no content#");
     }

--- a/src/ext_convert.ts
+++ b/src/ext_convert.ts
@@ -188,7 +188,7 @@ class RuleParser {
     private parseString(): ParseResult<string> {
         this.ignoreSpace();
         if (this.peek() != "'") {
-            return Err("expect a rule string starting with ', found " + this.peek());
+            return Err("Expected a rule starting with ', but found " + this.peek());
         }
         this.eat();
         const result: string[] = [];
@@ -214,7 +214,7 @@ class RuleParser {
                     // parse succ
                     return Ok(result.join(''));
                 case EOF:
-                    return Err("expect a rule string, found EOF");
+                    return Err("Expected a rule, but found EOF");
                 default:
                     result.push(ch);
                     break;
@@ -230,7 +230,7 @@ class RuleParser {
         } else if (first === '-' && second === 'x') {
             return Ok(ArrowType.Delete);
         }
-        return Err(`expect -> or -x, found ${first}${second}`);
+        return Err(`Expected -> or -x, but found ${first}${second}`);
     }
 
     private parseComment(): ParseResult<string> {
@@ -245,7 +245,7 @@ class RuleParser {
             }
         }
         if (ch != '\n' && ch != EOF) {
-            return Err("Expect one rule ending with newline or EOF, found " + ch);
+            return Err("Expected only one rule in each line, but found " + ch);
         }
         return Ok("#no content#");
     }
@@ -274,20 +274,20 @@ class RuleParser {
         const rule = new Rule();
         if (this.isSideRule()) {
             if (r2.value === ArrowType.Delete) {
-                return Err("map arrow for side insert should be ->");
+                return Err("Expected ->, but found -x (selection rules can't be deletion rules)");
             }
             const rightInsert = this.parseString();
             if (!rightInsert.isOk) { return Err(rightInsert.error); }
             const sideRule = new SideRule(r1.value, r3.value, rightInsert.value);
             if (!sideRule.isValid) {
-                return Err("the trigger of a side insert rule should be a single char");
+                return Err("Expected one char, but found multiple (the selection rule trigger char can only be a single character)");
             }
             rule.type = RuleType.SideRule;
             rule.side = sideRule;
         } else {
             const convRule = new ConvRule(r1.value, r3.value, r2.value === ArrowType.Delete);
             if (!convRule.isValid) {
-                return Err("rule shuold has one and only |. And the left rule can't starts with |");
+                return Err("Expected one | in each side, but found multiple. The left side can't start with |.");
             }
             rule.type = RuleType.ConvRule;
             rule.conv = convRule;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -128,8 +128,7 @@ function createRuleEditorInContainer(container: HTMLElement, plugin: TypingTrans
     // source: obsidian-latex-suite setting tab
     const convertRulesSetting = new Setting(container)
         .setName("Rules")
-        .setDesc("Enter converting & selection rules here. Each line is one rule and rules that come first \
-                      have higher priority. Lines starting with \"#\" will be treated as comments and ignored.")
+        .setDesc("Enter conversion, selection, and deletion rules here. Each line is one rule. Rules that come first have higher priority. Lines starting with \"#\" will be treated as comments and ignored.")
         .setClass("rules-text-area");
 
 


### PR DESCRIPTION
I've found the error messages a little hard to understand. I've tried my best to clean it up (I hope I didn't mess anything up). 

I have a few suggestions though:
1. Do not allow rules to span over multiple lines like this, it makes the error messages misleading
```
'\n》|' -> 'abc|
'
```
The error messages become misleading when you have rules also on the next line:
![image](https://user-images.githubusercontent.com/103465188/183536229-a7405b35-69dc-41b5-a051-19d0f07f50a7.png)
"line 13"? but the issue is with the additional characters in line 14.

---

2. Split this kind of error into multiple ones.
*Formerly: `rule shuold has one and only |. And the left rule can't starts with |`*

a. One for missing `|`:
`'abc' -> 'abcd'`
Error: `Expected one | on each side, but missing | [on left/right side]`

One for having too many `|`:
`'abc||' -> 'abcd'`
Error: `Expected one | on each side, but found multiple [on left/right side]`

One for having it in the wrong place:
`'|abc' -> 'abcd'`
Error: `Invalid placement of |.` OR `The left side cannot start with |.`

Also, if it is possible I would recommend you to split the checks for this into two, one for each side. This way, you can detect issues on each side individually.

For example:
``'|abc' -> 'abcd'``
Has two issues: missing | and invalid placement of |.

If you split it up, you can have two errors for the same line, telling the user these errors.

---

3. Put error messages into multiple lines

![image](https://user-images.githubusercontent.com/103465188/183537705-99498ff3-8db5-48c0-aca7-342483fc694f.png)
This is quite hard to read