### PR TITLE
fix: keep the surrounding space of other block

### DIFF
--- a/charliberty/src/lib.rs
+++ b/charliberty/src/lib.rs
@@ -35,6 +35,6 @@ pub fn get_block_ranges(line: &str, cursor_pos: usize) -> Blocks {
     let (sp, em) = block_ranges(line, cursor_pos);
     Blocks {
         special: sp,
-        emphasis: em
+        emphasis: em,
     }
 }


### PR DESCRIPTION
fix #10 

3 + 5 will be recoginzed as three blocks: `3(num)` `+ (other)` + `5(num)` (single space is ignored by parser, except the space in other block)

in previous space-adding rules, no spaces were added on both sides of `other` block, so the result is `3+ 5`

now, we found there is a natural space on the left of `other` block, and we keep it