### PR TITLE
Dynamically register and unregister profile commands

### DIFF
--- a/src/global_commands.ts
+++ b/src/global_commands.ts
@@ -16,9 +16,16 @@ export function getAllCommands(plugin: TypingTransformer): Command[] {
         editorCallback: async (_e: Editor, _v: MarkdownView) => await plugin.toggleIndicator()
     };
 
-    const ret = [format, zone];
+    const profileCommands = generateProfileCommands(plugin);
 
+    return [format, zone, ...profileCommands];
+}
 
+export function profileCommandNameFromIndex(index: number): string {
+  return `typing-trans-p${index.toString()}`
+}
+
+export function generateProfileCommands(plugin: TypingTransformer): Command[] {
     const useProfileX = async (i: number) => {
         const profs = plugin.settings.profiles;
         if (i >= profs.length) {
@@ -32,15 +39,23 @@ export function getAllCommands(plugin: TypingTransformer): Command[] {
         plugin.configureProfile(title, newRule);
     };
 
-    for (let i = 0; i < 6; i++) {
+    const ret = [];
+
+    const profiles = plugin.settings.profiles;
+
+    for (let [i, profile] of profiles.entries()) {
+        // We use the index here as it will overwrite existing commands with shared indices. As long
+        // as we call this on settings exit, which we DO, the commands should always work and have
+        // the correct name.
         const useProfileCommand = {
-            id: "typing-trans-p" + i.toString(),
-            name: "apply profile " + i.toString() + (i === 0 ? " (global)" : ""),
+            id: profileCommandNameFromIndex(i),
+            name: "Apply '" + profile.title + "' Profile",
             editorCallback: async (_e: Editor, _v: MarkdownView) => {
                 await useProfileX(i);
             }
         };
         ret.push(useProfileCommand);
     }
+
     return ret;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { initLog, log } from './utils';
 import { Rules, DEL_TRIG } from './ext_convert';
 import { libertyZone } from './ext_libertyzone';
 import { TypingTransformerSettings, SettingTab, DEFAULT_SETTINGS } from './settings';
-import { getAllCommands } from './global_commands';
+import { generateProfileCommands, getAllCommands } from './global_commands';
 
 
 enum ExtID {
@@ -116,6 +116,9 @@ export default class TypingTransformer extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+		for (const cmd of generateProfileCommands(this)) {
+				this.addCommand(cmd);
+		}
 	}
 
 	configureProfile = async (title: string, ruleString: string) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
 import { python } from "@codemirror/lang-python";
 import { tags as t } from "@lezer/highlight";
 import { log } from "./utils";
+import { profileCommandNameFromIndex } from "./global_commands";
 
 export const config = {
     name: "obsidian",
@@ -50,7 +51,7 @@ const obsidianTheme = EditorView.theme({
 });
 
 
-export const BaseProfileName = "global";
+export const BaseProfileName = "Global";
 const ProfileSwitch = Annotation.define<boolean>();
 
 interface Profile {
@@ -172,7 +173,7 @@ function createRuleEditorInContainer(container: HTMLElement, plugin: TypingTrans
     ol.createEl("li", { text: "The character '|' indicates where your cursor will be placed after the rule is applied."}); //note 3
     ol.createEl("li", { text: "To use special characters like '|' for conversion, you escape them with a backslash, for example: '\\|' "}); 
     ol.createEl("li", { text: "Whatever tab you are on when the plugin settings tab quits will be the profile that is chosen" });
-    ol.createEl("li", { text: "The 'global' profile will always be active" });
+    ol.createEl("li", { text: "The 'Global' profile will always be active" });
 
     const convertRulesSetting = new Setting(container)
         .setName("Rules")
@@ -289,6 +290,14 @@ function createRuleEditorInContainer(container: HTMLElement, plugin: TypingTrans
         if (el === state.selectedProfileEl)
             // switch to base profile
             onProfileClick(BaseProfileName, state.baseProfileEl);
+
+        // If we remove a profile, we want to remove its profile command as well.
+        let profileIndex = plugin.settings.profiles.findIndex((p) => p.title === name);
+        if (profileIndex) {
+            let commandName = profileCommandNameFromIndex(profileIndex);
+            plugin.removeCommand(commandName);
+        }
+        
         state.profilesMap.delete(name);
         state.editedProfile.add(name);
         profilesContainer.removeChild(el);


### PR DESCRIPTION
Previously the plugin registered six commands to activate profiles, even if there were fewer than six. These commands also had no mapping to the profile name, making it hard to remember which is which.

Command names are now generated from the profile name, and they can be registered and unregistered dynamically as users create them. This may open a route to removing the six-profile limit in the future, but I didn't want to tackle that as part of this PR.